### PR TITLE
SEO-204825-js-H1tag-missing-Hotfix

### DIFF
--- a/js/Menu/Separators.md
+++ b/js/Menu/Separators.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Separators
-description: separators
+title: Separators | Menu | Syncfusion
+description: Check out and learn here everything about separators of Syncfusion JavaScript Menu and much more details.
 platform: js
 control: Menu
 documentation: ug
@@ -87,10 +87,10 @@ Add the following **&lt;script&gt;** in the above code sample to display the **M
 
 The following screenshot displays the output for the above code. 
 
-![](/js/Menu/Separators_images/Separators_img2.png) 
+![Separators menu.](/js/Menu/Separators_images/Separators_img2.png) 
 
 
-# Separators for Context Menu
+## Separators for Context Menu
 
 We can add the separators for particular ContextMenu items by including **e-separator** class in the required **LI** elements. Add the following code to display ContextMenu with separator lines.
 
@@ -150,6 +150,6 @@ We can add the separators for particular ContextMenu items by including **e-sepa
 
 The following screenshot displays the output for the above code. 
 
-![](/js/Menu/Separators_images/Separators_img3.png) 
+![Separators for Context Menu.](/js/Menu/Separators_images/Separators_img3.png) 
 
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 tag missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |
|Meta content | Meta title and description too short, so i changed it|
|Add the image alt tag | Image alt tag missing, so i add it|




Regards, 
Asha