### PR TITLE
seo-205214-Javascript-H1-tag-Missing-hotfix

### DIFF
--- a/js/WCF/Northwind.md
+++ b/js/WCF/Northwind.md
@@ -7,7 +7,7 @@ platform: js
 keywords: Northwind, syncfusion, Northwind wcf
 ---
 
-## NorthwindDataService
+# NorthwindDataService
 
  [GET] [/WCF/Northwind.svc](http://js.syncfusion.com/demos/ejservices/Wcf/Northwind.svc)
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/205214/|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B13A50D72-C3C5-4635-90F2-E36DE3A8B07C%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |




Regards, 
Asha