### PR TITLE
SEO-205214-Image-Alt-Missing-JS-Hotfix

### DIFF
--- a/js/Chart/Chart-Series.md
+++ b/js/Chart/Chart-Series.md
@@ -48,7 +48,7 @@ In EjChart, you can add multiple series object in the [`series`](../api/js/ejcha
 
 {% endhighlight %}
 
-![](/js/Chart/Chart-Series_images/Chart-Series_img1.png)
+![multiple series in Chart](/js/Chart/Chart-Series_images/Chart-Series_img1.png)
 
 
 [Click](https://ej2.syncfusion.com/home/#!/azure/chart/column) here to view the multiple series online demo sample.
@@ -99,7 +99,7 @@ The following code example explains on how to enable marker, tooltip and animati
 
 {% endhighlight %} 
 
-![](/js/Chart/Chart-Series_images/Chart-Series_img2.png)
+![customizing all series together in Chart.](/js/Chart/Chart-Series_images/Chart-Series_img2.png)
 
 
 ## Combination Series
@@ -128,7 +128,7 @@ EjChart allows you to render the combination of different series in the chart.
 
 {% endhighlight %}
 
-![](/js/Chart/Chart-Series_images/Chart-Series_img3.png)
+![combination Series in Chart.](/js/Chart/Chart-Series_images/Chart-Series_img3.png)
 
 
 [Click](https://ej2.syncfusion.com/home/#!/azure/chart/combination) here to view the combination series online demo sample.
@@ -172,7 +172,7 @@ When the combination of Cartesian and accumulation series types are added to the
 
 {% endhighlight %}
 
-![](/js/Chart/Chart-Series_images/Chart-Series_img4.png)
+![limitation of combination chart.](/js/Chart/Chart-Series_images/Chart-Series_img4.png)
 
 ## Init Series render
 

--- a/js/Chart/Empty-Points.md
+++ b/js/Chart/Empty-Points.md
@@ -34,7 +34,7 @@ The Data points that uses the **null** or **undefined** as value are considered 
 
 {% endhighlight %}
 
-![](/js/Chart/Empty-Points_images/Empty-Points_img1.png)
+![empty points in Chart.](/js/Chart/Empty-Points_images/Empty-Points_img1.png)
 
 
 [Click](https://ej2.syncfusion.com/home/#!/azure/chart/chartcustomization/emptypoints) here to view the online demo sample for empty points.
@@ -62,7 +62,7 @@ You can customize the empty points visibility and change its [`displayMode`](../
 
 {% endhighlight %}
 
-![](/js/Chart/Empty-Points_images/Empty-Points_img2.png)
+![empty point settings in chart.](/js/Chart/Empty-Points_images/Empty-Points_img2.png)
 
 
 If the [`visible`](../api/ejchart.html#members:series-emptypointsettings-visible) property of [`emptyPointSettings`](../api/ejchart.html#members:series-emptypointsettings) is *false*, then the empty points has been dropped and chart will be rendered without empty points.
@@ -97,4 +97,4 @@ Empty points [`color`](../api/ejchart.html#members:series-emptypointsettings-sty
 
 {% endhighlight %}
 
-![](/js/Chart/Empty-Points_images/Empty-Points_img4.png)
+![customizing styles in Chart.](/js/Chart/Empty-Points_images/Empty-Points_img4.png)

--- a/js/DataManager/Filtering.md
+++ b/js/DataManager/Filtering.md
@@ -92,7 +92,7 @@ This operator is used to get the records with values less than that of the filte
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img1.png) 
+![filter operators in Data Manager.](Filtering_images/Filtering_img1.png) 
 
 ## greaterThan
 
@@ -145,7 +145,7 @@ This operator is used to get the records with values greater than that of the fi
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img2.png) 
+![greater than in Data Manager.](Filtering_images/Filtering_img2.png) 
 
 ## lessThanOrEqual
 
@@ -200,7 +200,7 @@ This operator is used to get the records with values less than or equal to the f
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img3.png) 
+![less than or equal of Data Manager.](Filtering_images/Filtering_img3.png) 
 
 ## greaterThanOrEqual
 
@@ -254,7 +254,7 @@ This operator is used to get the records with values greater than or equal to th
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img4.png) 
+![greater than or equal of Data Manager.](Filtering_images/Filtering_img4.png) 
 
 ## equal
 
@@ -306,7 +306,7 @@ This operator is used to get the records with values equal to that of the filter
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img5.png) 
+![equal in Data Manager.](Filtering_images/Filtering_img5.png) 
 
 ## notEqual
 
@@ -359,7 +359,7 @@ This operator is used to get the records with values not equal to that of the fi
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img6.png) 
+![not equal in Data Manager.](Filtering_images/Filtering_img6.png) 
 
 ## contains
 
@@ -414,7 +414,7 @@ This operator is used to get the records that contains the filter value.
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img7.png) 
+![contains of Data Manager.](Filtering_images/Filtering_img7.png) 
 
 ## startswith
 
@@ -467,7 +467,7 @@ This operator is used to get the records that starts with the filter value speci
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img8.png) 
+![starts with of Data Manager.](Filtering_images/Filtering_img8.png) 
 
 ## endswith
 
@@ -521,7 +521,7 @@ This operator is used to get the records that ends with the filter value specifi
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img9.png) 
+![ends with of Data Manager.](Filtering_images/Filtering_img9.png) 
 
 ## and predicate
 
@@ -575,7 +575,7 @@ The `and` predicate is used to add n-number of predicates with “and” conditi
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img10.png) 
+![and predicate of Data Manager.](Filtering_images/Filtering_img10.png) 
 
 ## or predicate
 
@@ -630,7 +630,7 @@ Using this method you can add n-number of predicates with `or` condition and fil
 
 Result of the above code example is illustrated as follows.
 
-![](Filtering_images/Filtering_img11.png) 
+![or predicate of Data Manager.](Filtering_images/Filtering_img11.png) 
 
 ## Containment Operators
 
@@ -682,7 +682,7 @@ This operator is used to get the records that not contains the filter value.
 
 {% endhighlight %}
 
-![](Filtering_images/Filtering_image111.png) 
+![not contains of Data Manager.](Filtering_images/Filtering_image111.png) 
 
 ### contains
 
@@ -732,7 +732,7 @@ This operator is used to get the records that contains the filter value.
 
 {% endhighlight %}
 
-![](Filtering_images/Filtering_image12.png) 
+![contains of Data Manager.](Filtering_images/Filtering_image12.png) 
 
 ### in
 
@@ -782,7 +782,7 @@ This operator used to fetch the records with value match with the given filter v
 
 {% endhighlight %}
 
-![](Filtering_images/Filtering_image13.png) 
+![in contains of Data Manager.](Filtering_images/Filtering_image13.png) 
 
 ### notin
 
@@ -832,9 +832,9 @@ This operator used to fetch the records with value not match with the given filt
 
 {% endhighlight %}
 
-![](Filtering_images/Filtering_image14.png) 
+![not in containment of Data Manager.](Filtering_images/Filtering_image14.png) 
 
-![](Filtering_images/Filtering_image15.png) 
+![not in containment of Javascript Data Manager.](Filtering_images/Filtering_image15.png) 
 
 ## Lambda Operators
 
@@ -883,7 +883,7 @@ The ALL operator returns true if all the sub query values meet the condition. Th
 
 {% endhighlight %}
 
-![](Filtering_images/Filtering_image16.png) 
+![all lambda operators of Data Manager.](Filtering_images/Filtering_image16.png) 
 
 ### any
 
@@ -932,4 +932,4 @@ The ANY operator returns true if any of the sub query values meet the condition.
 
 {% endhighlight %}
 
-![](Filtering_images/Filtering_image17.png) 
+![any lambda operators of Data Manager.](Filtering_images/Filtering_image17.png) 

--- a/js/DateTimePicker/Globalization.md
+++ b/js/DateTimePicker/Globalization.md
@@ -106,5 +106,5 @@ Add the following code in your **HTML** page.
 
 {% endhighlight %}
 
-![](/js/DateTimePicker/Globalization_images/Globalization_img1.png)
+![globalization in Date Time Pcker.](/js/DateTimePicker/Globalization_images/Globalization_img1.png)
 

--- a/js/Grid/Grouping.md
+++ b/js/Grid/Grouping.md
@@ -33,7 +33,7 @@ $(function () {
 
 The following output is displayed as a result of the above code example.
 
-![](Grouping_images/Grouping_img1.png)
+![grouping in Javascript Grid.](Grouping_images/Grouping_img1.png)
 
 
 ## Initial Grouping
@@ -61,7 +61,7 @@ $(function () {
 
 The following output is displayed as a result of the above code example.
 
-![](Grouping_images/Grouping_img2.png)
+![initial grouping in Javascript Grid.](Grouping_images/Grouping_img2.png)
 
 
 ## Multi-Column Grouping
@@ -90,7 +90,7 @@ $(function () {
 
 The following output is displayed as a result of the above code example.
 
-![](Grouping_images/Grouping_img3.png)
+![multi-column grouping in Javascript Grid.](Grouping_images/Grouping_img3.png)
 
 
 ## Group buttons
@@ -118,7 +118,7 @@ $(function () {
 
 The following output is displayed as a result of the above code example.
 
-![](Grouping_images/Grouping_img4.png)
+![group buttons of Javascrit Grid.](Grouping_images/Grouping_img4.png)
 
 
 ## Hide Ungroup button
@@ -146,7 +146,7 @@ $(function () {
 
 The following output is displayed as a result of the above code example.
 
-![](Grouping_images/Grouping_img5.png)
+![hide ungroup button in Javascript Grid.](Grouping_images/Grouping_img5.png)
 
 
 ## Hide Grouped Column
@@ -174,7 +174,7 @@ $(function () {
 
 The following output is displayed as a result of the above code example.
 
-![](Grouping_images/Grouping_img6.png)
+![hide grouped column in Javascript Grid.](Grouping_images/Grouping_img6.png)
 
 
 ## AutoSize Drop Area
@@ -202,7 +202,7 @@ $(function () {
 
 The following output is displayed as a result of the above code example.
 
-![](Grouping_images/Grouping_img7.png)
+![auto size drop area in Javascript Grid.](Grouping_images/Grouping_img7.png)
 
 
 ## Hide Drop area
@@ -230,7 +230,7 @@ $(function () {
 
 The following output is displayed as a result of the above code example.
 
-![](Grouping_images/Grouping_img8.png)
+![hide drop area in Javascript Grid.](Grouping_images/Grouping_img8.png)
 
 
 ## Group Caption Format / Group Caption Template
@@ -278,10 +278,10 @@ function btnClick(args) {
 
 The following output is displayed as a result of the above code example.
 
-![](Grouping_images/Grouping_img9.png)
+![group caption format in Javascript Grid.](Grouping_images/Grouping_img9.png)
 
 
-![](Grouping_images/Grouping_img10.png)
+![group caption template in Javacript Grid.](Grouping_images/Grouping_img10.png)
 
 
 ### Perform Grouping by External Action:-
@@ -343,7 +343,7 @@ $(function () {
 
 The following output is displayed as a result of the previous code example.
 
-![](Grouping_images/Grouping_img11.png)
+![perform grouping by external action in Javascript Grid.](Grouping_images/Grouping_img11.png)
 
 ## Handling grouped records count in server-side    
 
@@ -417,4 +417,4 @@ $(function () {
 
 The following output is displayed as a result of the above code example.
 
-![](Grouping_images/Grouping_img12.png)
+![handling grouped records count in server-side in Javascript Grid.](Grouping_images/Grouping_img12.png)


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/205214/|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B13A50D72-C3C5-4635-90F2-E36DE3A8B07C%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|




Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha