### PR TITLE
SEO-206704-JS-H1-tag-Missing-hotfix

### DIFF
--- a/js/WCF/Northwind.md
+++ b/js/WCF/Northwind.md
@@ -7,7 +7,7 @@ platform: js
 keywords: Northwind, syncfusion, Northwind wcf
 ---
 
-## NorthwindDataService
+# NorthwindDataService
 
  [GET] [/WCF/Northwind.svc](http://js.syncfusion.com/demos/ejservices/Wcf/Northwind.svc)
 

--- a/js/WebAPI/Spreadsheet.md
+++ b/js/WebAPI/Spreadsheet.md
@@ -7,7 +7,7 @@ platform: js
 keywords: Spreadsheet,ejSpreadsheet , syncfusion, ejSpreadsheet webapi
 ---
 
-## ExcelExport
+# ExcelExport
 
  [POST] [/Api/Spreadsheet/ExcelExport](http://js.syncfusion.com/demos/ejServices/api/Spreadsheet/ExcelExport)
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/206704|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BC1479F0A-9619-4A7C-B47E-C05E2DB08DD9%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |





Regards, 
Asha